### PR TITLE
Bugfix: do not reorder submit controls even if names are shared

### DIFF
--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -446,6 +446,39 @@ def test_submit_button():
     ...
     """
 
+def test_repeated_button():
+    """
+    >>> app = TestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> app.set_next_response(b'''\
+    ... <html><body>
+    ...     <form method='get' action='action'>
+    ...         <input name='one' value='Button' type='submit'>
+    ...         <input name='two' value='Button' type='submit'>
+    ...         <input name='one' value='Button' type='submit'>
+    ...     </form>
+    ... </body></html>
+    ... ''')
+    >>> browser.open('http://localhost/foo') # doctest: +ELLIPSIS
+    GET /foo HTTP/1.1
+    ...
+
+    >>> browser.getControl('Button')
+    Traceback (most recent call last):
+      ...
+    AmbiguityError: label 'Button' matches:
+      <SubmitControl(one=Button)>
+      <SubmitControl(two=Button)>
+      <SubmitControl(one=Button)>
+
+    >>> browser.getControl('Button', index=0)
+    <SubmitControl name='one' type='submit'>
+    >>> browser.getControl('Button', index=1)
+    <SubmitControl name='two' type='submit'>
+    >>> browser.getControl('Button', index=2)
+    <SubmitControl name='one' type='submit'>
+    """
+
 def test_suite():
     return doctest.DocTestSuite(
         checker=zope.testbrowser.tests.helper.checker,


### PR DESCRIPTION
Discovered this issue in a test suite of a real project.

There's a submit button repeated twice: once at the top of the form, once at the bottom.  It shares the same `value` (i.e. button label) with the third button that exists in the middle of the form.

The old testbrowser assigned indexes to the three buttons in order of HTML appearance.  The current testbrowser groups them by name first, which breaks my tests.

I'm not very happy with the solution, can you suggest refactorings?

I haven't explored what happens if you have the same `name` shared between checkboxes and other controls.  It should probably be resolved before merging this.
