### PR TITLE
Add another Layer to combine with `zope.app.wsgi.testlayer.BrowserLayer`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ CHANGES
         from unittest import TestSuite
         import doctest
         import zope.app.wsgi.testlayer
+        import zope.testbrowser.wsgi
 
         class Layer(zope.testbrowser.wsgi.TestBrowserLayer,
                     zope.app.wsgi.testlayer.BrowserLayer):

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,16 +30,14 @@ CHANGES
     Example: if your test file looked like this ::
 
         # my/package/tests.py
-        from unittest import TestSuite
-        import doctest
-        import zope.app.wsgi.testlayer
-
-        layer = zope.app.wsgi.testlayer.BrowserLayer(my.package)
+        from zope.app.testing.functional import defineLayer
+        from zope.app.testing.functional import FunctionalDocFileSuite
+        defineLayer('MyFtestLayer', 'ftesting.zcml', allow_teardown=True)
 
         def test_suite():
-            suite = doctest.DocFileSuite('test.txt', ...)
-            suite.layer = layer
-            return TestSuite((suite,))
+            suite = FunctionalDocFileSuite('test.txt', ...)
+            suite.layer = MyFtestLayer
+            return suite
 
     now you'll have to use ::
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,29 +29,35 @@ CHANGES
 
     Example: if your test file looked like this ::
 
-        # my/package/tests/test_all.py
-        from zope.app.testing.functional import defineLayer
-        from zope.app.testing.functional import FunctionalDocFileSuite
-        defineLayer('MyFtestLayer', 'ftesting.zcml', allow_teardown=True)
-
-        def test_suite():
-            suite = FunctionalDocFileSuite('test.txt', ...)
-            suite.layer = MyFtestLayer
-            return suite
-
-    now you'll have to use ::
-
-        # my/package/tests/test_all.py
+        # my/package/tests.py
+        from unittest import TestSuite
         import doctest
-        from zope.app.wsgi.testlayer import BrowserLayer
-        import my.package.tests
+        import zope.app.wsgi.testlayer
 
-        MyFtestLayer = BrowserLayer(my.package.tests, 'ftesting.zcml')
+        layer = zope.app.wsgi.testlayer.BrowserLayer(my.package)
 
         def test_suite():
             suite = doctest.DocFileSuite('test.txt', ...)
-            suite.layer = MyFtestLayer
-            return suite
+            suite.layer = layer
+            return TestSuite((suite,))
+
+    now you'll have to use ::
+
+        # my/package/tests.py
+        from unittest import TestSuite
+        import doctest
+        import zope.app.wsgi.testlayer
+
+        class Layer(zope.testbrowser.wsgi.TestBrowserLayer,
+                    zope.app.wsgi.testlayer.BrowserLayer):
+            """Layer to prepare zope.testbrowser using the WSGI app."""
+
+        layer = Layer(my.package)
+
+        def test_suite():
+            suite = doctest.DocFileSuite('test.txt', ...)
+            suite.layer = layer
+            return TestSuite((suite,))
 
     and then change all your tests from ::
 
@@ -251,7 +257,7 @@ CHANGES
 3.7.0a1 (2009-08-29)
 --------------------
 
-- Update dependency from ``zope.app.publisher`` to 
+- Update dependency from ``zope.app.publisher`` to
   ``zope.browserpage``, ``zope.browserresource`` and ``zope.ptresource``.
 
 - Remove dependencies on ``zope.app.principalannotation`` and

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -75,9 +75,23 @@ Example when using the layer:
     ...     def make_wsgi_app(self):
     ...         return zope.testbrowser.wsgi.AuthorizationMiddleware(simple_app)
 
-There is also a BrowserLayer in `zope.app.wsgi.testlayer`_ which does this
+There is also a ``BrowserLayer`` in `zope.app.wsgi.testlayer`_ which does this
 for you and includes a ``TransactionMiddleware``, too, which could be handy
 when testing a ZODB based application.
+
+However, since the ``BrowserLayer`` in `zope.app.wsgi.testlayer`_ re-creates
+the ZODB in ``testSetUp``, we need to re-create the WSGI App during
+``testSetUp``, too. Therefore use ``TestBrowserLayer`` of
+``zope.testbrowser.wsgi`` instead of the simpler ``Layer`` to combine it with
+the ``BrowserLayer`` in `zope.app.wsgi.testlayer`_:
+
+.. doctest::
+
+    >>> import zope.testbrowser.wsgi
+    >>> import zope.app.wsgi.testlayer
+    >>> class Layer(zope.testbrowser.wsgi.TestBrowserLayer,
+    ...             zope.app.wsgi.testlayer.BrowserLayer):
+    ...     pass
 
 .. _`zope.app.wsgi.testlayer` : http://pypi.python.org/pypi/zope.app.wsgi
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open('CHANGES.rst') as f:
 
 long_description = (README + '\n\n' + CHANGES)
 
-tests_require = ['zope.testing']
+tests_require = ['zope.testing', 'mock']
 
 setup(
     name='zope.testbrowser',

--- a/src/zope/testbrowser/tests/test_wsgi.py
+++ b/src/zope/testbrowser/tests/test_wsgi.py
@@ -31,7 +31,7 @@ class SimpleLayer(zope.testbrowser.wsgi.Layer):
 SIMPLE_LAYER = SimpleLayer()
 
 
-class WSGILayer(object):
+class AppLayer(object):
 
     def make_wsgi_app(self):
         return demo_app
@@ -43,11 +43,11 @@ class WSGILayer(object):
         pass
 
 
-class SimpleWSGILayer(zope.testbrowser.wsgi.TestBrowserLayer, WSGILayer):
+class TestBrowserLayer(zope.testbrowser.wsgi.TestBrowserLayer, AppLayer):
 
     pass
 
-SIMPLE_WSGI_LAYER = SimpleWSGILayer()
+TEST_BROWSER_LAYER = TestBrowserLayer()
 
 
 class TestBrowser(unittest.TestCase):
@@ -235,9 +235,9 @@ class TestTestBrowserLayer(unittest.TestCase):
 
     @contextlib.contextmanager
     def wsgi_layer(self):
-        SIMPLE_WSGI_LAYER.testSetUp()
+        TEST_BROWSER_LAYER.testSetUp()
         yield
-        SIMPLE_WSGI_LAYER.testTearDown()
+        TEST_BROWSER_LAYER.testTearDown()
 
     def test_layer(self):
         """When the layer is setup, the wsgi_app argument is unnecessary"""
@@ -248,17 +248,17 @@ class TestTestBrowserLayer(unittest.TestCase):
 
     def test_there_can_only_be_one(self):
         with self.wsgi_layer():
-            another_layer = SimpleWSGILayer()
+            another_layer = TestBrowserLayer()
             self.assertRaises(AssertionError, another_layer.testSetUp)
 
     def test_supports_multiple_inheritance(self):
         with mock.patch('zope.testbrowser.tests.test_wsgi'
-                        '.WSGILayer.testSetUp') as testSetUp:
-            SIMPLE_WSGI_LAYER.testSetUp()
+                        '.AppLayer.testSetUp') as testSetUp:
+            TEST_BROWSER_LAYER.testSetUp()
             self.assertEqual(1, testSetUp.call_count)
         with mock.patch('zope.testbrowser.tests.test_wsgi'
-                        '.WSGILayer.testTearDown') as testTearDown:
-            SIMPLE_WSGI_LAYER.testTearDown()
+                        '.AppLayer.testTearDown') as testTearDown:
+            TEST_BROWSER_LAYER.testTearDown()
             self.assertEqual(1, testTearDown.call_count)
 
     def test_raise_error_when_make_wsgi_app_is_not_implemented(self):
@@ -267,10 +267,10 @@ class TestTestBrowserLayer(unittest.TestCase):
 
     def test_do_not_raise_error_when_make_wsgi_app_returns_None(self):
         with mock.patch('zope.testbrowser.tests.test_wsgi'
-                        '.WSGILayer.make_wsgi_app') as make_wsgi_app:
+                        '.AppLayer.make_wsgi_app') as make_wsgi_app:
             make_wsgi_app.return_value = None
-            SIMPLE_WSGI_LAYER.testSetUp()
-            SIMPLE_WSGI_LAYER.testTearDown()
+            TEST_BROWSER_LAYER.testSetUp()
+            TEST_BROWSER_LAYER.testTearDown()
 
 
 class TestAuthorizationMiddleware(unittest.TestCase):

--- a/src/zope/testbrowser/tests/test_wsgi.py
+++ b/src/zope/testbrowser/tests/test_wsgi.py
@@ -261,6 +261,17 @@ class TestWSGILayer(unittest.TestCase):
             SIMPLE_WSGI_LAYER.testTearDown()
             self.assertEqual(1, testTearDown.call_count)
 
+    def test_raise_error_when_make_wsgi_app_is_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            zope.testbrowser.wsgi.WSGILayer().testSetUp()
+
+    def test_do_not_raise_error_when_make_wsgi_app_returns_None(self):
+        with mock.patch('zope.testbrowser.tests.test_wsgi'
+                        '.WSGILayer.make_wsgi_app') as make_wsgi_app:
+            make_wsgi_app.return_value = None
+            SIMPLE_WSGI_LAYER.testSetUp()
+            SIMPLE_WSGI_LAYER.testTearDown()
+
 
 class TestAuthorizationMiddleware(unittest.TestCase):
 

--- a/src/zope/testbrowser/tests/test_wsgi.py
+++ b/src/zope/testbrowser/tests/test_wsgi.py
@@ -37,15 +37,15 @@ class AppLayer(object):
         return demo_app
 
     def testSetUp(self):
-        pass
+        """Stub to mock it in test to check it was called."""
 
     def testTearDown(self):
-        pass
+        """Stub to mock it in test to check it was called."""
 
 
 class TestBrowserLayer(zope.testbrowser.wsgi.TestBrowserLayer, AppLayer):
+    """Prepare `_APP_UNDER_TEST` with `make_wsgi_app` from `AppLayer`."""
 
-    pass
 
 TEST_BROWSER_LAYER = TestBrowserLayer()
 

--- a/src/zope/testbrowser/tests/test_wsgi.py
+++ b/src/zope/testbrowser/tests/test_wsgi.py
@@ -43,7 +43,7 @@ class WSGILayer(object):
         pass
 
 
-class SimpleWSGILayer(zope.testbrowser.wsgi.WSGILayer, WSGILayer):
+class SimpleWSGILayer(zope.testbrowser.wsgi.TestBrowserLayer, WSGILayer):
 
     pass
 
@@ -231,7 +231,7 @@ class TestLayer(unittest.TestCase):
         self.assertRaises(AssertionError, another_layer.setUp)
 
 
-class TestWSGILayer(unittest.TestCase):
+class TestTestBrowserLayer(unittest.TestCase):
 
     @contextlib.contextmanager
     def wsgi_layer(self):
@@ -263,7 +263,7 @@ class TestWSGILayer(unittest.TestCase):
 
     def test_raise_error_when_make_wsgi_app_is_not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            zope.testbrowser.wsgi.WSGILayer().testSetUp()
+            zope.testbrowser.wsgi.TestBrowserLayer().testSetUp()
 
     def test_do_not_raise_error_when_make_wsgi_app_returns_None(self):
         with mock.patch('zope.testbrowser.tests.test_wsgi'

--- a/src/zope/testbrowser/tests/test_wsgi.py
+++ b/src/zope/testbrowser/tests/test_wsgi.py
@@ -229,6 +229,7 @@ class TestLayer(unittest.TestCase):
         # available
         self.assertRaises(AssertionError, another_layer.setUp)
 
+
 class TestWSGILayer(unittest.TestCase):
 
     def test_layer(self):

--- a/src/zope/testbrowser/wsgi.py
+++ b/src/zope/testbrowser/wsgi.py
@@ -90,6 +90,8 @@ _APP_UNDER_TEST = None  # setup and torn down by the Layer class
 class Layer(object):
     """Test layer which sets up WSGI app for use with WebTest/testbrowser.
 
+    Inherit from this layer and overwrite `make_wsgi_app` for setup.
+
     Composing multiple layers into one is supported using plone.testing.Layer.
 
     """
@@ -128,8 +130,19 @@ class Layer(object):
 class WSGILayer(object):
     """Test layer which sets up WSGI app for use with WebTest/testbrowser.
 
-    Composing multiple layers into one is supported by inheritance, e.g. to
-    combine zope.app.wsgi.BrowserLayer with this one.
+    This layer is intended for use cases, where `make_wsgi_app` is implemented
+    by another class using multiple inheritance.
+
+    We used `testSetUp` and `testTearDown` instead of `setUp` and `tearDown` to
+    cooperate with layers from other zope packages, e.g.
+    `zope.app.wsgi.testlayer.BrowserLayer`, since they re-create the DB
+    connection during `testSetUp`. Therefore we need to re-create the app, too.
+
+    Make sure this layer always comes first in multiple inheritance, because
+    the requirements of other layers should be set up before calling
+    `make_wsgi_app`. In addition, many layers do not make sure to call multiple
+    superclasses using something like `cooperative_super`, thus the methods of
+    this layer may not be called if it comes later.
 
     """
 

--- a/src/zope/testbrowser/wsgi.py
+++ b/src/zope/testbrowser/wsgi.py
@@ -127,7 +127,7 @@ class Layer(object):
         self.cooperative_super('tearDown')
 
 
-class WSGILayer(object):
+class TestBrowserLayer(object):
     """Test layer which sets up WSGI app for use with WebTest/testbrowser.
 
     This layer is intended for use cases, where `make_wsgi_app` is implemented
@@ -148,14 +148,14 @@ class WSGILayer(object):
 
     def cooperative_super(self, method_name):
         # Calling `super` for multiple inheritance:
-        method = getattr(super(WSGILayer, self), method_name, None)
+        method = getattr(super(TestBrowserLayer, self), method_name, None)
         if method is not None:
             return method()
 
     def make_wsgi_app(self):
-        if not hasattr(super(WSGILayer, self), 'make_wsgi_app'):
+        if not hasattr(super(TestBrowserLayer, self), 'make_wsgi_app'):
             raise NotImplementedError
-        return super(WSGILayer, self).make_wsgi_app()
+        return super(TestBrowserLayer, self).make_wsgi_app()
 
     def testSetUp(self):
         self.cooperative_super('testSetUp')

--- a/src/zope/testbrowser/wsgi.py
+++ b/src/zope/testbrowser/wsgi.py
@@ -137,7 +137,12 @@ class WSGILayer(object):
         # Calling `super` for multiple inheritance:
         method = getattr(super(WSGILayer, self), method_name, None)
         if method is not None:
-            method()
+            return method()
+
+    def make_wsgi_app(self):
+        if not hasattr(super(WSGILayer, self), 'make_wsgi_app'):
+            raise NotImplementedError
+        return super(WSGILayer, self).make_wsgi_app()
 
     def testSetUp(self):
         self.cooperative_super('testSetUp')

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ commands =
 deps =
     Sphinx
     repoze.sphinx.autointerface
+    zope.app.wsgi
 
 [testenv:flake8]
 basepython = python2


### PR DESCRIPTION
The CHANGES.rst mentions how to convert old test setups to the new API. However, the code example seems wrong to me, since it does not use `zope.testbrowser.wsgi.Layer`.

When trying to use the layer in other zope packages, e.g. `zope.globalrequest`, we found out that `zope.testbrowser.wsgi.Layer` cannot be combined with `zope.app.wsgi.testlayer.BrowserLayer` using multiple inheritance, because:

- Since `zope.testbrowser.wsgi.Layer` raises a `NotImplementedError` when it comes first in the inheritance chain, the implementation in `zope.app.wsgi.testlayer.BrowserLayer` is never called.
- Moving `zope.testbrowser.wsgi.Layer` behind `zope.app.wsgi.testlayer.BrowserLayer` in the inheritance chain also won't work, since `zope.app.wsgi.testlayer.BrowserLayer` does not use something like `cooperative_supper`, thus the `testSetUp` of `zope.testbrowser.wsgi.Layer` is never called.
- Since the `zope.app.appsetup.testlayer.ZODBLayer` re-creates the DB during `testSetUp`, we also have to re-create the app on `testSetUp`. 😞 

Therefore I have decided to add *another* Layer that can be combined with `zope.app.wsgi.testlayer.BrowserLayer`. I spoke about the solution with @dhavlik and @icemac and they approved the idea.