### PR TITLE
Declare Python 3.5 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 *.pyc
 *.so
 *.dll
+.Python
 __pycache__
+include/
+lib/
 src/*.egg-info
 
 .installed.cfg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,7 +84,7 @@ CHANGES
 
   - ``zope.testbrowser[zope-functional-testing]``
 
-- Add support for Python 3.3 and 3.4.
+- Add support for Python 3.3, 3.4 and 3.5.
 
 - Drop support for Python 2.5.
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Testing',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py33,py34,docs
+    py26,py27,py33,py34,py35,docs
 
 [testenv]
 deps =


### PR DESCRIPTION
Was already included in the `.travis.yml` in #17.