### PR TITLE
Improve API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,11 @@
 CHANGES
 =======
 
-5.0.1 (unreleased)
-------------------
+5.1 (unreleased)
+----------------
 
-- Nothing changed yet.
+- Alias ``.browser.urllib_request.HTTPError`` to ``.browser.HTTPError`` to have
+  a better API.
 
 
 5.0.0 (2016-09-30)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ tests_require = ['zope.testing', 'mock']
 
 setup(
     name='zope.testbrowser',
-    version='5.0.1.dev0',
+    version='5.1.dev0',
     url='https://github.com/zopefoundation/zope.testbrowser',
     license='ZPL 2.1',
     description='Programmable browser for functional black-box tests',

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -282,7 +282,6 @@ class Browser(SetattrErrorsMixin):
                     resp = self.testapp.get(url, **reqargs)
             assert remaining_redirects > 0, "redirects chain looks infinite"
             self._setResponse(resp)
-            HTTPError = urllib_request.HTTPError
             self._checkStatus()
 
     def _checkStatus(self):

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -36,6 +36,7 @@ import webtest
 
 __docformat__ = "reStructuredText"
 
+HTTPError = urllib_request.HTTPError
 RegexType = type(re.compile(''))
 _compress_re = re.compile(r"\s+")
 
@@ -44,7 +45,7 @@ class HostNotAllowed(Exception):
     pass
 
 
-class RobotExclusionError(urllib_request.HTTPError):
+class RobotExclusionError(HTTPError):
     def __init__(self, *args):
         super(RobotExclusionError, self).__init__(*args)
 
@@ -281,6 +282,7 @@ class Browser(SetattrErrorsMixin):
                     resp = self.testapp.get(url, **reqargs)
             assert remaining_redirects > 0, "redirects chain looks infinite"
             self._setResponse(resp)
+            HTTPError = urllib_request.HTTPError
             self._checkStatus()
 
     def _checkStatus(self):
@@ -289,7 +291,7 @@ class Browser(SetattrErrorsMixin):
             code, msg = self.headers['Status'].split(' ', 1)
             code = int(code)
             if self.raiseHttpErrors and code >= 400:
-                raise urllib_request.HTTPError(self.url, code, msg, [], None)
+                raise HTTPError(self.url, code, msg, [], None)
 
     def _submit(self, form, name=None, index=None, coord=None, **args):
         # A reimplementation of webtest.forms.Form.submit() to allow to insert


### PR DESCRIPTION
Alias ``.browser.urllib_request.HTTPError`` to ``.browser.HTTPError`` to have a better API.