### PR TITLE
Don't follow redirects for all 30x response status codes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ CHANGES
 5.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fixed browser to only follow redirects for HTTP statuses
+  301, 302, 303, and 307; not other 30x statuses such as 304.
 
 
 5.1 (2017-01-31)

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -55,6 +55,8 @@ _allowed_2nd_level = set(['example.com', 'example.net', 'example.org'])
 _allowed = set(['localhost', '127.0.0.1'])
 _allowed.update(_allowed_2nd_level)
 
+REDIRECTS = (301, 302, 303, 307)
+
 
 class TestbrowserApp(webtest.TestApp):
     _last_fragment = ""
@@ -275,7 +277,7 @@ class Browser(SetattrErrorsMixin):
             self._history.add(self._response)
             resp = make_request(reqargs)
             remaining_redirects = 100  # infinite loops protection
-            while 300 <= resp.status_int < 400 and remaining_redirects:
+            while resp.status_int in REDIRECTS and remaining_redirects:
                 remaining_redirects -= 1
                 url = urlparse.urljoin(url, resp.headers['location'])
                 with self._preparedRequest(url) as reqargs:

--- a/src/zope/testbrowser/ftests/wsgitestapp.py
+++ b/src/zope/testbrowser/ftests/wsgitestapp.py
@@ -177,8 +177,7 @@ def echo_one(req):
 
 def set_status(req):
     status = req.params.get('status')
+    body = req.params.get('body', 'Just set a status of %s' % status)
     if status:
-        resp = Response('Just set a status of %s' % status)
-        resp.status = int(status)
-        return resp
+        return Response(body, status=int(status))
     return Response('Everything fine')


### PR DESCRIPTION
Some 30x codes do not indicate redirects, such as 304.

This follows redirects for the same status codes that mechanize did
(301, 302, 303, 307)