### PR TITLE
Fixed ``toStr`` to handle lists, for example a list of class names.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ CHANGES
 5.2 (unreleased)
 ----------------
 
+- Fixed ``toStr`` to handle lists, for example a list of class names.
+  [maurits]
+
 - Fixed browser to only follow redirects for HTTP statuses
   301, 302, 303, and 307; not other 30x statuses such as 304.
 

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -528,6 +528,12 @@ class Browser(SetattrErrorsMixin):
             return s
         if s is None:
             return None
+        # Might be an iterable, especially the 'class' attribute.
+        if isinstance(s, (list, tuple)):
+            subs = [self.toStr(sub) for sub in s]
+            if isinstance(s, tuple):
+                return tuple(subs)
+            return subs
         if PYTHON2 and not isinstance(s, bytes):
             return s.encode(self._response.charset)
         if not PYTHON2 and isinstance(s, bytes):

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -957,6 +957,24 @@ def test_controls_without_value(self):
     """
 
 
+def test_multiple_classes(self):
+    """
+    >>> app = TestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> app.set_next_response(b'''\
+    ... <html><body>
+    ... <a href="" class="one two">A link</a>
+    ... </body></html>
+    ... ''')
+    >>> browser.open('http://localhost/')
+    GET / HTTP/1.1
+    ...
+    >>> from pprint import pprint
+    >>> pprint(browser.getLink('A link').attrs)
+    {'class': ['one', 'two'], 'href': ''}
+    """
+
+
 def test_suite():
     return doctest.DocTestSuite(
         checker=zope.testbrowser.tests.helper.checker,


### PR DESCRIPTION
Sample error in Plone coredev for Zope 4:

```
File "/home/jenkins/workspace/plip-zope4/src/Products.CMFPlacefulWorkflow/Products/CMFPlacefulWorkflow/tests/policy_form.txt", line 66, in policy_form.txt
Failed example:
    'state-visible' in foo_link.attrs['class']
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest policy_form.txt[30]>", line 1, in <module>
        'state-visible' in foo_link.attrs['class']
      File "/home/jenkins/workspace/plip-zope4/src/zope.testbrowser/src/zope/testbrowser/browser.py", line 616, in attrs
        return dict((toStr(k), toStr(v)) for k, v in self._link.attrs.items())
      File "/home/jenkins/workspace/plip-zope4/src/zope.testbrowser/src/zope/testbrowser/browser.py", line 616, in <genexpr>
        return dict((toStr(k), toStr(v)) for k, v in self._link.attrs.items())
      File "/home/jenkins/workspace/plip-zope4/src/zope.testbrowser/src/zope/testbrowser/browser.py", line 532, in toStr
        return s.encode(self._response.charset)
    AttributeError: 'list' object has no attribute 'encode'
```
