### PR TITLE
Fix uploading real files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ CHANGES
 - Fixed browser to only follow redirects for HTTP statuses
   301, 302, 303, and 307; not other 30x statuses such as 304.
 
+- Fix passing a real file to ``add_file``.
+
 
 5.1 (2017-01-31)
 ----------------

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -698,7 +698,7 @@ class Control(SetattrErrorsMixin):
             raise TypeError("Can't call add_file on %s controls"
                             % self.mech_control.type)
 
-        if isinstance(file, io.IOBase):
+        if hasattr(file, 'read'):
             contents = file.read()
         else:
             contents = file

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -347,8 +347,11 @@ def test_file_upload():
 
     Fill in the form value using add_file:
 
-    >>> browser.getControl(name='foo').add_file(
-    ...     io.BytesIO(b'sample_data'), 'text/foo', 'x.txt')
+    >>> import tempfile
+    >>> data = tempfile.NamedTemporaryFile()
+    >>> num_bytes = data.write(b'sample_data')
+    >>> position = data.seek(0)
+    >>> browser.getControl(name='foo').add_file(data, 'text/foo', 'x.txt')
     >>> browser.getControl('OK').click() # doctest: +REPORT_NDIFF +ELLIPSIS
     POST / HTTP/1.1
     ...
@@ -357,6 +360,7 @@ def test_file_upload():
     <BLANKLINE>
     sample_data
     ...
+    >>> del data
 
     You can pass a string to add_file:
 
@@ -369,6 +373,19 @@ def test_file_upload():
     Content-type: text/csv
     <BLANKLINE>
     blah blah blah
+    ...
+
+    or a BytesIO object:
+
+    >>> browser.getControl(name='foo').add_file(
+    ...     io.BytesIO(b'sample_data'), 'text/foo', 'x.txt')
+    >>> browser.getControl('OK').click() # doctest: +REPORT_NDIFF +ELLIPSIS
+    POST / HTTP/1.1
+    ...
+    Content-Disposition: form-data; name="foo"; filename="x.txt"
+    Content-Type: text/foo
+    <BLANKLINE>
+    sample_data
     ...
 
     You can assign a value


### PR DESCRIPTION
Always convert an uploaded file to a string, don't pass files just because they're real files.