### PR TITLE
Allow newer WebTest versions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ CHANGES
 5.3 (unreleased)
 ----------------
 
-- Pin to `WebTest < 2.0.27` as newer versions break some tests.
+- Exclude version 2.0.27 of `WebTest` from allowed versions as it breaks some
+  tests.
 
 
 5.2 (2017-02-25)

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'zope.schema',
         'zope.cachedescriptors',
         'pytz > dev',
-        'WebTest >= 2.0.9, < 2.0.27',
+        'WebTest >= 2.0.9, != 2.0.27',
         'WSGIProxy2',
         'six',
     ],

--- a/src/zope/testbrowser/ftests/wsgitestapp.py
+++ b/src/zope/testbrowser/ftests/wsgitestapp.py
@@ -131,6 +131,10 @@ def set_header(req):
     resp = Response()
     body = [u"Set Headers:"]
     for k, v in sorted(req.params.items()):
+        if not isinstance(k, str):
+            k = k.encode('latin1')
+        if not isinstance(v, str):
+            v = v.encode('latin1')
         body.extend([k, v])
         resp.headers.add(k, v)
     resp.unicode_body = u'\n'.join(body)


### PR DESCRIPTION
2.0.28 fixed the regressions we saw with 2.0.27.
A big thank you goes to @fschulze for doing bringing up the fix there.

Fixes #30.