### PR TITLE
Radio & list controls: select item by index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,11 @@
 CHANGES
 =======
 
-5.3 (unreleased)
-----------------
+5.2.2 (unreleased)
+------------------
 
-- Nothing changed yet.
+- Fix selecting radio and select control options by index
+  (https://github.com/zopefoundation/zope.testbrowser/issues/31).
 
 
 5.2.1 (2017-09-01)
@@ -29,11 +30,11 @@ CHANGES
 
 - Fix passing a real file to ``add_file``.
 
-- Add `controls` property to Form class to list all form controls.
+- Add ``controls`` property to Form class to list all form controls.
 
 - Restore the ability to use parts of the actually displayed select box titles.
 
-- Allow to set a string value instead of a list on `Browser.displayValue`.
+- Allow to set a string value instead of a list on ``Browser.displayValue``.
 
 - Fix setting empty values on a select control.
 
@@ -51,7 +52,7 @@ CHANGES
 ------------------
 
 - Converted most doctests to Sphinx documentation, and published to
-  http://zopetestbrowser.rtfd.org/ .
+  https://zopetestbrowser.readthedocs.io/ .
 
 - Internal implementation now uses WebTest instead of ``mechanize``.
   The ``mechanize`` dependency is completely dropped.
@@ -111,7 +112,7 @@ CHANGES
 
         >>> from zope.testbrowser.wsgi import Browser
 
- Â   Maybe the blog post `Getting rid of zope.app.testing`_ could help you adapting to this new version, too.
+    Maybe the blog post `Getting rid of zope.app.testing`_ could help you adapting to this new version, too.
 
 - Remove modules:
 
@@ -223,7 +224,7 @@ CHANGES
 3.11.0 (2011-01-24)
 -------------------
 
-- Add `wsgi_intercept` support (came from ``zope.app.wsgi.testlayer``).
+- Add ``wsgi_intercept`` support (came from ``zope.app.wsgi.testlayer``).
 
 
 3.10.4 (2011-01-14)

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -726,6 +726,21 @@ may also be searched by label.
     >>> browser.getControl('Tres')
     <ItemControl name='single-select-value' type='select' optionValue='3' selected=False>
 
+Radio fields can even have the same name and value and only be distinguished
+by the id.
+
+    >>> browser.getControl(name='radio-value-a')
+    <ListControl name='radio-value-a' type='radio'>
+    >>> browser.getControl(name='radio-value-a').getControl(value='true', index=0)
+    <ItemControl name='radio-value-a' type='radio' optionValue='true' selected=False>
+    >>> browser.getControl(name='radio-value-a').getControl(value='true', index=1)
+    <ItemControl name='radio-value-a' type='radio' optionValue='true' selected=False>
+    >>> browser.getControl(name='radio-value-a').getControl(value='true', index=1).selected = True
+    >>> browser.getControl(name='radio-value-a').getControl(value='true', index=0)
+    <ItemControl name='radio-value-a' type='radio' optionValue='true' selected=False>
+    >>> browser.getControl(name='radio-value-a').getControl(value='true', index=1)
+    <ItemControl name='radio-value-a' type='radio' optionValue='true' selected=True>
+
 Characteristics of controls and subcontrols are discussed below.
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ tests_require = ['zope.testing', 'mock']
 
 setup(
     name='zope.testbrowser',
-    version='5.3.dev0',
+    version='5.2.2.dev0',
     url='https://github.com/zopefoundation/zope.testbrowser',
     license='ZPL 2.1',
     description='Programmable browser for functional black-box tests',

--- a/src/zope/testbrowser/ftests/controls.html
+++ b/src/zope/testbrowser/ftests/controls.html
@@ -112,6 +112,11 @@
       </div>
 
       <div>
+        <input type="radio" name="radio-value-a" id="radio-value-a-1" value="true" />
+        <input type="radio" name="radio-value-a" id="radio-value-a-2" value="true" />
+      </div>
+
+      <div>
         <label for="image-value">Image Control</label>
         <em>%(image-value.x)s</em>
         <em>%(image-value.y)s</em>

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -771,6 +771,49 @@ def test_subcontrols_can_be_selected_by_value():
     """
 
 
+def test_subcontrols_with_same_value_can_be_distinguished():
+    """Regression test for GH #31.
+
+    https://github.com/zopefoundation/zope.testbrowser/issues/31
+
+    >>> app = TestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> app.set_next_response(b'''\
+    ... <html><body>
+    ...     <form method='get' action='action'>
+    ...         <input id="bar1" type='radio' name='bar' value="a">
+    ...         <label for="bar1">First</label>
+    ...         <input id="bar2" type='radio' name='bar' value="a">
+    ...         <label for="bar2">Second</label>
+    ...         <br>
+    ...         <select name="baz">
+    ...             <option value="b">uno</option>
+    ...             <option value="b">duos</option>
+    ...         </select>
+    ...     </form>
+    ... </body></html>
+    ... ''')
+    >>> browser.open('http://localhost/foo') # doctest: +ELLIPSIS
+    GET /foo HTTP/1.1
+    ...
+
+    >>> radiobuttons = browser.getControl(name='bar')
+    >>> radiobuttons.getControl(value='a', index=1).selected = True
+    >>> radiobuttons.getControl(value='a', index=0)
+    <ItemControl name='bar' type='radio' optionValue='a' selected=False>
+    >>> radiobuttons.getControl(value='a', index=1)
+    <ItemControl name='bar' type='radio' optionValue='a' selected=True>
+
+    >>> listcontrol = browser.getControl(name='baz')
+    >>> listcontrol.getControl(value='b', index=1).selected = True
+    >>> listcontrol.getControl(value='b', index=0)
+    <ItemControl name='baz' type='select' optionValue='b' selected=False>
+    >>> listcontrol.getControl(value='b', index=1)
+    <ItemControl name='baz' type='select' optionValue='b' selected=True>
+
+    """
+
+
 def test_option_with_explicit_value_and_first_value_an_empty_string():
     """
     >>> app = YetAnotherTestApp()


### PR DESCRIPTION
This allows us to disambiguate multiple items that have the same value.

Fixes #31.