### PR TITLE
Fix form submit with GET method if the form action contains a query string.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 5.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix form submit with GET method if the form action contains a query string.
 
 
 5.2.3 (2017-10-18)

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -304,9 +304,13 @@ class Browser(SetattrErrorsMixin):
             fields.extend([('%s.x' % name, coord[0]),
                            ('%s.y' % name, coord[1])])
 
+        url = self._absoluteUrl(form.action)
         if form.method.upper() != "GET":
-            args.setdefault("content_type",  form.enctype)
-        return form.response.goto(form.action, method=form.method,
+            args.setdefault("content_type", form.enctype)
+        else:
+            parsed = urlparse.urlparse(url)._replace(query='', fragment='')
+            url = urlparse.urlunparse(parsed)
+        return form.response.goto(url, method=form.method,
                                   params=fields, **args)
 
     def _setResponse(self, response):

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -1120,6 +1120,28 @@ def test_multiple_classes(self):
     """
 
 
+def test_form_get_method_with_querystring_in_action(self):
+    """
+    >>> app = TestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> app.set_next_response(b'''\
+    ... <html><body>
+    ... <form action="/?bar=1" method="get">
+    ... <input type="text" name="foo" />
+    ... <input type="submit" />
+    ... </form>
+    ... </body></html>
+    ... ''')
+    >>> browser.open('http://localhost/?bar=1')
+    GET /?bar=1 HTTP/1.1
+    ...
+    >>> browser.getControl(name="foo").value = "bar"
+    >>> browser.getForm().submit()
+    GET /?foo=bar HTTP/1.1
+    ...
+    """
+
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([


### PR DESCRIPTION
I tested this behavior with real browsers and it also works in zope.testbrowser < 5.

Here is the pyramid app I used for testing:
```python
from wsgiref.simple_server import make_server
from pyramid.config import Configurator
from pyramid.response import Response


def form_view(request):
    tmp = """<!doctype html>
    <form action="/?bar=1" method="get">
    <input type="text" name="foo" />
    <input type="submit" />
    </form>
    <pre>%s</pre>
    """
    return Response(tmp % request.GET)


if __name__ == '__main__':
    with Configurator() as config:
        config.add_route('root', '/')
        config.add_view(form_view, route_name='root')
        app = config.make_wsgi_app()
    server = make_server('0.0.0.0', 8080, app)
    server.serve_forever()
```