### PR TITLE
Fix `mechRepr` of CheckboxListControl to always return a native str.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ CHANGES
 
 - Drop support for Python 3.3 and 3.4.
 
+- Fix ``mechRepr`` of CheckboxListControl to always return a native str.
+  (https://github.com/zopefoundation/zope.testbrowser/pull/46).
+
 
 5.2.4 (2017-11-24)
 ------------------

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -1025,7 +1025,8 @@ class CheckboxListControl(SetattrErrorsMixin):
         self.value = []
 
     def mechRepr(self):
-        return "<SelectControl(%s=[*, ambiguous])>" % self.name
+        return "<SelectControl(%s=[*, ambiguous])>" % self.browser.toStr(
+            self.name)
 
     @Lazy
     def labels(self):

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -136,6 +136,7 @@ class TestMechRepr(unittest.TestCase):
                   <select name="sel1">
                     <option value="op">Türn</option>
                   </select>
+                  <input name="check1" type="checkbox" value="šêlėçtèd" />
                   <input name="sub1" type="submit" value="Yës" />
                 </form>
               </body>
@@ -156,6 +157,14 @@ class TestMechRepr(unittest.TestCase):
             mech_repr,
             "<Item name='op' id=None contents='Türn' value='op'"
             " label='Türn'>")
+
+    def test_CheckboxListControl_has_str_mechRepr(self):
+        from ..browser import CheckboxListControl
+        ctrl = self.browser.getControl(name='check1')
+        self.assertIsInstance(ctrl, CheckboxListControl)
+        mech_repr = ctrl.mechRepr()
+        self.assertIsInstance(mech_repr, str)
+        self.assertEqual(mech_repr, '<SelectControl(check1=[*, ambiguous])>')
 
     def test_SubmitControl_has_str_mechRepr(self):
         mech_repr = self.browser.getControl(name='sub1').mechRepr()


### PR DESCRIPTION
This is a leftover of #38 resp. #36.