### PR TITLE
[WIP] Add `mechRepr` to input fields having the type `email`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ CHANGES
 - Fix ``mechRepr`` of CheckboxListControl to always return a native str.
   (https://github.com/zopefoundation/zope.testbrowser/pull/46).
 
+- Add ``mechRepr`` to input fields having the type ``email``.
+  (https://github.com/zopefoundation/zope.testbrowser/pull/47).
+
 
 5.2.4 (2017-11-24)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'zope.schema',
         'zope.cachedescriptors',
         'pytz > dev',
-        'WebTest > 2.0.29',
+        'WebTest >= 2.0.30',
         'WSGIProxy2',
         'six',
     ],

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'zope.schema',
         'zope.cachedescriptors',
         'pytz > dev',
-        'WebTest >= 2.0.9, != 2.0.27',
+        'WebTest > 2.0.29',
         'WSGIProxy2',
         'six',
     ],

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -748,7 +748,7 @@ class Control(SetattrErrorsMixin):
         # emulate mechanize control representation
         toStr = self.browser.toStr
         ctrl = self._control
-        if isinstance(ctrl, webtest.forms.Text):
+        if isinstance(ctrl, (webtest.forms.Text, webtest.forms.Email)):
             tp = ctrl.attrs.get('type')
             infos = []
             if 'readonly' in ctrl.attrs or tp == 'hidden':
@@ -757,7 +757,8 @@ class Control(SetattrErrorsMixin):
                 infos.append('disabled')
 
             classnames = {'password': "PasswordControl",
-                          'hidden': "HiddenControl"
+                          'hidden': "HiddenControl",
+                          'email': "EMailControl",
                           }
             clname = classnames.get(tp, "TextControl")
             return "<%s(%s=%s)%s>" % (

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -137,6 +137,7 @@ class TestMechRepr(unittest.TestCase):
                     <option value="op">Türn</option>
                   </select>
                   <input name="check1" type="checkbox" value="šêlėçtèd" />
+                  <input name="mail1" type="email" value="i@me.com" />
                   <input name="sub1" type="submit" value="Yës" />
                 </form>
               </body>
@@ -165,6 +166,12 @@ class TestMechRepr(unittest.TestCase):
         mech_repr = ctrl.mechRepr()
         self.assertIsInstance(mech_repr, str)
         self.assertEqual(mech_repr, '<SelectControl(check1=[*, ambiguous])>')
+
+    def test_Control_for_type_email_has_mechRepr(self):
+        option = self.browser.getControl(name='mail1')
+        mech_repr = option.mechRepr()
+        self.assertIsInstance(mech_repr, str)
+        self.assertEqual(mech_repr, "<EMailControl(mail1=i@me.com)>")
 
     def test_SubmitControl_has_str_mechRepr(self):
         mech_repr = self.browser.getControl(name='sub1').mechRepr()

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
 
 [testenv]
 deps =
+    git+https://github.com/gocept/webtest.git@f65c263#egg=WebTest
     .[test]
     zope.testrunner
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
 
 [testenv]
 deps =
-    git+https://github.com/gocept/webtest.git@f65c263#egg=WebTest
+    git+https://github.com/Pylons/webtest.git#egg=WebTest
     .[test]
     zope.testrunner
 commands =
@@ -23,6 +23,7 @@ commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
+    git+https://github.com/Pylons/webtest.git#egg=WebTest
     Sphinx
     repoze.sphinx.autointerface
     zope.app.wsgi

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist =
 
 [testenv]
 deps =
-    git+https://github.com/Pylons/webtest.git#egg=WebTest
     .[test]
     zope.testrunner
 commands =
@@ -23,7 +22,6 @@ commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
-    git+https://github.com/Pylons/webtest.git#egg=WebTest
     Sphinx
     repoze.sphinx.autointerface
     zope.app.wsgi


### PR DESCRIPTION
This requires a merge and release in WebTest. See Pylons/webtest#194.

Open issues:

- [x] New release of WebTest
- [x] Drop using git checkouts of WebTest