### PR TITLE
Drop support for pystone as Python 3.7 dropped pystone.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ CHANGES
 
 - Drop support for Python 3.3 and 3.4.
 
+- Drop support for pystone as Python 3.7 dropped pystone. So
+  ``Browser.lastRequestPystones`` no longer exists. Rename
+  ``.browser.PystoneTimer`` to ``.browser.Timer``.
+
 - Fix ``mechRepr`` of CheckboxListControl to always return a native str.
   (https://github.com/zopefoundation/zope.testbrowser/pull/46).
 

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -1632,15 +1632,12 @@ Performance Testing
 
 Browser objects keep up with how much time each request takes.  This can be
 used to ensure a particular request's performance is within a tolerable range.
-Be very careful using raw seconds, cross-machine differences can be huge,
-pystones is usually a better choice.
+Be very careful using raw seconds, cross-machine differences can be huge.
 
 .. doctest::
 
     >>> browser.open('http://localhost/@@/testbrowser/simple.html')
     >>> browser.lastRequestSeconds < 10 # really big number for safety
-    True
-    >>> browser.lastRequestPystones < 10000 # really big number for safety
     True
 
 

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -140,7 +140,7 @@ class Browser(SetattrErrorsMixin):
     __html = None
 
     def __init__(self, url=None, wsgi_app=None):
-        self.timer = PystoneTimer()
+        self.timer = Timer()
         self.raiseHttpErrors = True
         self.handleErrors = True
 
@@ -169,11 +169,6 @@ class Browser(SetattrErrorsMixin):
     def isHtml(self):
         """See zope.testbrowser.interfaces.IBrowser"""
         return self._response and 'html' in self._response.content_type
-
-    @property
-    def lastRequestPystones(self):
-        """See zope.testbrowser.interfaces.IBrowser"""
-        return self.timer.elapsedPystones
 
     @property
     def lastRequestSeconds(self):
@@ -1401,21 +1396,9 @@ def isMatching(string, expr):
         return normalizeWhitespace(expr) in normalizeWhitespace(string)
 
 
-class PystoneTimer(object):
+class Timer(object):
     start_time = 0
     end_time = 0
-    _pystones_per_second = None
-
-    @property
-    def pystonesPerSecond(self):
-        """How many pystones are equivalent to one second on this machine"""
-
-        # deferred import as workaround for Zope 2 testrunner issue:
-        # http://www.zope.org/Collectors/Zope/2268
-        from test import pystone
-        if self._pystones_per_second is None:
-            self._pystones_per_second = pystone.pystones(pystone.LOOPS//10)[1]
-        return self._pystones_per_second
 
     def _getTime(self):
         if sys.platform.startswith('win'):
@@ -1446,14 +1429,6 @@ class PystoneTimer(object):
         else:
             end_time = self.end_time
         return end_time - self.start_time
-
-    @property
-    def elapsedPystones(self):
-        """Elapsed pystones in timing period
-
-        See elapsed_seconds for definition of timing period.
-        """
-        return self.elapsedSeconds * self.pystonesPerSecond
 
     def __enter__(self):
         self.start()

--- a/src/zope/testbrowser/interfaces.py
+++ b/src/zope/testbrowser/interfaces.py
@@ -212,17 +212,6 @@ class IBrowser(zope.interface.Interface):
         required=True,
         readonly=True)
 
-    lastRequestPystones = zope.schema.Field(
-        title=u"Approximate System-Independent Effort of Last Request "
-              u"(Pystones)",
-        description=(u"""Return how many pystones the last request took.
-
-        This number is found by multiplying the number of pystones/second at
-        which this system benchmarks and the result of ``lastRequestSeconds``.
-        """),
-        required=True,
-        readonly=True)
-
     def getControl(label=None, name=None, index=None):
         """Get a control from the page.
 


### PR DESCRIPTION
* `Browser.lastRequestPystones` no longer exists.
* Rename `.browser.PystoneTimer` to `.browser.Timer`.