### PR TITLE
Quote attribute values in CSS selectors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[flake8]
+doctests = yes

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -1367,7 +1367,7 @@ def getControlLabels(celem, html):
     # find all labels, connected by 'for' attribute
     controlid = celem.attrs.get('id')
     if controlid:
-        forlbls = html.select('label[for=%s]' % controlid)
+        forlbls = html.select('label[for="%s"]' % controlid)
         labels.extend([normalizeWhitespace(l.text) for l in forlbls])
 
     return [l for l in labels if l is not None]

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -1118,6 +1118,26 @@ def test_controls_without_value(self):
     """
 
 
+def test_controls_with_slightly_invalid_ids(self):
+    """
+    >>> app = TestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> app.set_next_response(b'''\
+    ... <html><body>
+    ... <form action="." method="post">
+    ... <label for="foo.field">Foo Label</label>
+    ... <input type="text" id="foo.field" value="Foo"/>
+    ... </form>
+    ... </body></html>
+    ... ''')
+    >>> browser.open('http://localhost/')
+    GET / HTTP/1.1
+    ...
+    >>> browser.getControl('Foo Label').value
+    'Foo'
+    """
+
+
 def test_multiple_classes(self):
     """
     >>> app = TestApp()


### PR DESCRIPTION
Fixes #61.

I've reviewed other uses of `html.select()` and AFAICs we're not doing anything else wrong.