### PR TITLE
Cookie expiration dates should be locale-independent

### DIFF
--- a/src/zope/testbrowser/cookies.py
+++ b/src/zope/testbrowser/cookies.py
@@ -50,11 +50,24 @@ class _StubResponse(object):
         return self.message
 
 
+DAY_OF_WEEK = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+MONTH = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+]
+
+
 def expiration_string(expires):  # this is not protected so usable in tests.
     if isinstance(expires, datetime.datetime):
         if expires.tzinfo is not None:
             expires = expires.astimezone(pytz.UTC)
-        expires = expires.strftime('%a, %d %b %Y %H:%M:%S GMT')
+        expires = expires.strftime(
+            '{dow}, %d {mon} %Y %H:%M:%S GMT'.format(
+                dow=DAY_OF_WEEK[expires.weekday()],
+                mon=MONTH[expires.month - 1],
+            )
+        )
     return expires
 
 # end Cookies class helpers

--- a/src/zope/testbrowser/tests/test_cookies.py
+++ b/src/zope/testbrowser/tests/test_cookies.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+import unittest
+import datetime
+import locale
+
+import pytz
+from zope.testbrowser.cookies import expiration_string
+
+
+class TestExpirationString(unittest.TestCase):
+
+    def test_string(self):
+        self.assertEqual(expiration_string("Wed, 02 Jan 2019 00:00:00 GMT"),
+                         "Wed, 02 Jan 2019 00:00:00 GMT")
+
+    def test_naive_datetime(self):
+        self.assertEqual(expiration_string(datetime.datetime(2019, 1, 2)),
+                         "Wed, 02 Jan 2019 00:00:00 GMT")
+
+    def test_timezone(self):
+        zone = pytz.timezone('Europe/Vilnius')
+        dt = zone.localize(datetime.datetime(2019, 1, 2, 14, 35))
+        self.assertEqual(expiration_string(dt),
+                         "Wed, 02 Jan 2019 12:35:00 GMT")
+
+    def test_locale_independence(self):
+        old_locale = locale.setlocale(locale.LC_TIME, "")
+        self.addCleanup(locale.setlocale, locale.LC_TIME, old_locale)
+        self.assertEqual(expiration_string(datetime.datetime(2019, 1, 2)),
+                         "Wed, 02 Jan 2019 00:00:00 GMT")


### PR DESCRIPTION
Incidentally sphinx-build doctest does call locale.setlocale() which explains why the cookie narrative tests always failed on my machine.

Fixes #65.