### PR TITLE
Escape CSS IDs correctly for SoupSieve, part 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ CHANGES
 - Fix a bug where clicking the selected radio button would unselect it.  See
   `issue 68 <https://github.com/zopefoundation/zope.testbrowser/issues/68>`_.
 
+- Fix another incompatibility with BeautifulSoup4 >= 4.7 that could result
+  in a SyntaxError from browser.getLink().  See `issue 61
+  <https://github.com/zopefoundation/zope.testbrowser/issues/61>`_.
+
 
 5.3.2 (2019-02-06)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ setup(
         'zope.cachedescriptors',
         'pytz > dev',
         'WebTest >= 2.0.30',
+        'BeautifulSoup4', # do we need to require >= 4.7.0?
+        'SoupSieve >= 1.9.0',
         'WSGIProxy2',
         'six',
     ],

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'zope.cachedescriptors',
         'pytz > dev',
         'WebTest >= 2.0.30',
-        'BeautifulSoup4', # do we need to require >= 4.7.0?
+        'BeautifulSoup4',
         'SoupSieve >= 1.9.0',
         'WSGIProxy2',
         'six',

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -27,6 +27,7 @@ from zope.interface import implementer
 from zope.cachedescriptors.property import Lazy
 from wsgiproxy.proxies import TransparentProxy
 from bs4 import BeautifulSoup
+from soupsieve import escape as css_escape
 
 from zope.testbrowser import interfaces
 from zope.testbrowser._compat import httpclient, PYTHON2
@@ -313,8 +314,8 @@ class Browser(SetattrErrorsMixin):
 
     def getLink(self, text=None, url=None, id=None, index=0):
         """See zope.testbrowser.interfaces.IBrowser"""
-        qa = 'a' if id is None else 'a#%s' % id
-        qarea = 'area' if id is None else 'area#%s' % id
+        qa = 'a' if id is None else 'a#%s' % css_escape(id)
+        qarea = 'area' if id is None else 'area#%s' % css_escape(id)
         html = self._html
         links = html.select(qa)
         links.extend(html.select(qarea))

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -1138,6 +1138,23 @@ def test_links_without_href(self):
     """
 
 
+def test_links_with_complicated_id(self):
+    """
+    >>> app = TestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> app.set_next_response(b'''\
+    ... <html><body>
+    ... <a href="/foo" id="form.foo">Foo</a>
+    ... </body></html>
+    ... ''')
+    >>> browser.open('http://localhost/')
+    GET / HTTP/1.1
+    ...
+    >>> browser.getLink(id='form.foo').url
+    'http://localhost/foo'
+    """
+
+
 def test_controls_without_value(self):
     """
     >>> app = TestApp()


### PR DESCRIPTION
Fixes another instance of #61, in getLink() this time.