### PR TITLE
Fix missing HTTP status handling in .reload()

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,9 @@ source = zope.testbrowser
 
 [report]
 precision = 2
+
+[paths]
+source =
+    src/
+    .tox/*/lib/python*/site-packages/
+    .tox/pypy*/site-packages/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ parts
 dist
 docs/_build
 tags
+.coverage.*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ CHANGES
 5.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a bug where browser.reload() would not follow redirects or raise
+  exceptions for bad HTTP statuses.  See `issue 75
+  <https://zopefoundation/zope.testbrowser/issue/75>`_.
 
 
 5.3.3 (2019-07-02)

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -192,10 +192,10 @@ class Browser(SetattrErrorsMixin):
         if self._response is None:
             raise BrowserStateError("no URL has yet been .open()ed")
 
-        req = self._response.request
-        with self._preparedRequest(self.url):
-            resp = self.testapp.request(req)
-            self._setResponse(resp)
+        def make_request(args):
+            return self.testapp.request(self._response.request)
+
+        self._processRequest(self.url, make_request)
 
     def goBack(self, count=1):
         """See zope.testbrowser.interfaces.IBrowser"""

--- a/src/zope/testbrowser/fixed-bugs.txt
+++ b/src/zope/testbrowser/fixed-bugs.txt
@@ -111,7 +111,7 @@ The problem is that e.g. a simple 403 status raises an exception.
 
 This is how it works with a simple open():
 
-    >>> browser.handleErrors=False
+    >>> browser.handleErrors = False
 
     >>> browser.open('http://localhost/set_status.html')
     >>> print(browser.contents)

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -240,10 +240,88 @@ def test_accept_language_header_non_us():
     """
 
 
+def test_redirect_after_reload():
+    r"""
+    When browser is redirected after a page reload, reload() will follow it
+
+    >>> app = YetAnotherTestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> html = (b'''\
+    ... <html><body>
+    ...   Please wait, generating the thing
+    ... </body></html>
+    ... ''')
+    >>> content_type = ('Content-Type', 'text/html; charset=UTF-8')
+    >>> app.add_response(html, headers=[content_type])
+
+    >>> redirect = ('Location', 'http://localhost/the_thing')
+    >>> app.add_response(b"Moved", headers=[redirect],
+    ...                  status=302, reason='Found')
+    >>> app.add_response(b"The Thing", headers=[content_type])
+
+    Start conversation
+
+    >>> browser.open("http://localhost/")
+
+    After reload, expect the browser to be redirected
+
+    >>> browser.reload()
+    >>> browser.url
+    'http://localhost/the_thing'
+    >>> browser.contents
+    'The Thing'
+
+    """
+
+
+def test_error_after_reload():
+    r"""
+    When browser is redirected after a page reload, reload() will check
+    for bad HTTP status codes
+
+    >>> app = YetAnotherTestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> browser.handleErrors = False
+    >>> html = (b'''\
+    ... <html><body>
+    ...   Please wait, generating the thing
+    ... </body></html>
+    ... ''')
+    >>> content_type = ('Content-Type', 'text/html; charset=UTF-8')
+    >>> app.add_response(html, headers=[content_type])
+
+    >>> app.add_response(b"These are not the droids you're looking for",
+    ...                  status=403, reason='Forbidden')
+
+    Start conversation
+
+    >>> browser.open("http://localhost/")
+
+    After reload, expect the error to be raised
+
+    XXX: I expected
+
+    ## >>> browser.reload()
+    ## Traceback (most recent call last):
+    ##   ...
+    ## HTTPError: HTTP Error 403: Forbidden
+
+    which is what the tests in fixed-bugs.txt get, but what I actually get
+    instead is
+
+    Traceback (most recent call last):
+      ...
+    webtest.app.AppError: Bad response: 403 Forbidden
+    (not 200 OK or 3xx redirect for http://localhost/)
+    These are not the droids you're looking for
+
+    """
+
+
 def test_reload_after_redirect():
     """
     When browser is redirected after form submit, reload() will not resubmit
-    oroginal form data.
+    original form data.
 
     >>> app = YetAnotherTestApp()
     >>> browser = Browser(wsgi_app=app)
@@ -1259,12 +1337,16 @@ def test_additional_hidden_element_with_by_label_search():
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTests([
+    optionflags = (
+        doctest.NORMALIZE_WHITESPACE
+        | doctest.ELLIPSIS
+        | doctest.IGNORE_EXCEPTION_DETAIL
+    )
+    suite = unittest.TestSuite([
         unittest.defaultTestLoader.loadTestsFromName(__name__),
         doctest.DocTestSuite(
             checker=zope.testbrowser.tests.helper.checker,
-            optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS),
+            optionflags=optionflags),
     ])
     return suite
 

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -309,6 +309,7 @@ def test_error_after_reload():
     which is what the tests in fixed-bugs.txt get, but what I actually get
     instead is
 
+    >>> browser.reload()
     Traceback (most recent call last):
       ...
     webtest.app.AppError: Bad response: 403 Forbidden

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,27 @@ deps =
     coverage
 commands =
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
+setenv =
+    COVERAGE_FILE=.coverage.{envname}
+
+[testenv:coverage-report]
+basepython = python3.6
+deps = coverage
+skip_install = true
+commands =
+    coverage erase
+    coverage combine
+    coverage report -m
+setenv =
+    COVERAGE_FILE=.coverage
+parallel_show_output = true
+depends =
+    py27,
+    py35,
+    py36,
+    py37,
+    pypy,
+    pypy3,
 
 [testenv:docs]
 basepython =


### PR DESCRIPTION
Fixes #75.

Also adds `tox -e coverage-report` and makes it report paths in src/ rather than .tox/py*/lib/python*/site-packages.

I would appreciate any help regarding the HTTP error raised in my new unit test.  Why am I getting webtest's AppError while fixed-bugs.txt gets zope.testbrowser's HTTPError in a similar situation?