### PR TITLE
Invalidate caches in Browser.goBack()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ CHANGES
 5.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a bug where ``browser.goBack()`` did not invalidate caches, so
+  subsequent queries could use data from the wrong response.  See `issue 83
+  <https://github.com/zopefoundation/zope.testbrowser/issues/83>`_.
 
 
 5.4.0 (2019-11-01)

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -310,6 +310,7 @@ class Browser(SetattrErrorsMixin):
 
     def _setResponse(self, response):
         self._response = response
+        self._changed()
 
     def getLink(self, text=None, url=None, id=None, index=0):
         """See zope.testbrowser.interfaces.IBrowser"""
@@ -475,7 +476,6 @@ class Browser(SetattrErrorsMixin):
         self._contents = None
         self._controls = {}
         self.__html = None
-        self._req_content_type = None
 
     @contextmanager
     def _preparedRequest(self, url):
@@ -510,7 +510,7 @@ class Browser(SetattrErrorsMixin):
 
         yield kwargs
 
-        self._changed()
+        self._req_content_type = None
         self.timer.stop()
 
     def _absoluteUrl(self, url):

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -425,6 +425,52 @@ def test_reload_after_post():
     """
 
 
+def test_goBack_changes_cached_html(self):
+    """
+    goBack() causes the browser to clear its cached parsed HTML, so queries
+    that rely on that use the correct response.
+
+    >>> app = TestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> app.set_next_response(b'''\
+    ... <html>
+    ...   <head><title>First page</title></head>
+    ...   <body><a href="foo">link</a></body>
+    ... </html>
+    ... ''')
+    >>> browser.open('http://localhost/')
+    GET / HTTP/1.1
+    ...
+    >>> browser.title
+    'First page'
+    >>> browser.getLink('link').url
+    'http://localhost/foo'
+
+    >>> app.set_next_response(b'''\
+    ... <html>
+    ...   <head><title>Second page</title></head>
+    ...   <body><a href="bar">link</a></body>
+    ... </html>
+    ... ''')
+    >>> browser.open('http://localhost/')
+    GET / HTTP/1.1
+    ...
+    >>> browser.title
+    'Second page'
+    >>> browser.getLink('link').url
+    'http://localhost/bar'
+
+    After going back, queries once again return answers based on the first
+    response.
+
+    >>> browser.goBack()
+    >>> browser.title
+    'First page'
+    >>> browser.getLink('link').url
+    'http://localhost/foo'
+    """
+
+
 def test_button_without_name(self):
     """
     This once blew up.


### PR DESCRIPTION
Most of the cached attributes invalidated by Browser._changed() were
based on the response, so it makes more sense to invalidate them from
Browser._setResponse.  This means that Browser.goBack() now invalidates
these caches, so subsequent uses of methods such as Browser.getLink()
work properly.

_req_content_type is an exception to this: this is a property of the
request, set by Browser.post(), and it still makes sense to clear this
in Browser._preparedRequest().

Fixes #83.