### PR TITLE
Add Browser.followRedirects option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ CHANGES
   subsequent queries could use data from the wrong response.  See `issue 83
   <https://github.com/zopefoundation/zope.testbrowser/issues/83>`_.
 
+- Support telling the browser not to follow redirects by setting
+  ``Browser.follow_redirects`` to False.  See `issue 79
+  <https://github.com/zopefoundation/zope.testbrowser/issues/79>`_.
+
 
 5.4.0 (2019-11-01)
 ------------------

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -208,6 +208,25 @@ def test_relative_redirect(self):
     """
 
 
+def test_disable_following_redirects(self):
+    """
+    If followRedirects is False, the browser does not follow redirects.
+
+    >>> app = YetAnotherTestApp()
+    >>> browser = Browser(wsgi_app=app)
+    >>> redirect = ('Location', 'http://localhost/the_thing')
+    >>> app.add_response(b"Moved", headers=[redirect],
+    ...                  status=302, reason='Found')
+
+    >>> browser.followRedirects = False
+    >>> browser.open('http://localhost/')
+    >>> browser.headers['Status']
+    '302 Found'
+    >>> browser.headers['Location']
+    'http://localhost/the_thing'
+    """
+
+
 def test_relative_open_allowed_after_non_html_page(self):
     """
     >>> app = YetAnotherTestApp()


### PR DESCRIPTION
This used to be possible with mechanize by calling
`browser.mech_browser.set_handle_redirect(False)`.  We now support it
directly.

Fixes #79.