### PR TITLE
Stop sending Referer on browser.open/browser.post

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ CHANGES
 5.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Stop sending a ``Referer`` header when ``browser.open`` or
+  ``browser.post`` is called directly.  See `issue 87
+  <https://github.com/zopefoundation/zope.testbrowser/issues/87>`_.
 
 
 5.5.0 (2019-11-11)


### PR DESCRIPTION
RFC 2616 14.36 says: "The Referer field MUST NOT be sent if the
Request-URI was obtained from a source that does not have its own URI,
such as input from the user keyboard."  In the context of a test
browser, `browser.open` is analogous to input from the user keyboard and
should not result in sending a `Referer` header.

We save the previous request's referrer in order to maintain the
appropriate state for `browser.reload`.

Fixes #87.