### PR TITLE
Add error checking to displayValue setters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,14 @@ CHANGES
   ``browser.post`` is called directly.  See `issue 87
   <https://github.com/zopefoundation/zope.testbrowser/issues/87>`_.
 
+- Add error checking to the setters for ``ListControl.displayValue`` and
+  ``CheckboxListControl.displayValue``: in line with the old
+  ``mechanize``-based implementation, these will now raise
+  ``ItemNotFoundError`` if any of the given values are not found, or
+  ``ItemCountError`` on trying to set more than one value on a single-valued
+  control.  See `issue 44
+  <https://github.com/zopefoundation/zope.testbrowser/issues/44>`_.
+
 
 5.5.0 (2019-11-11)
 ------------------

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -844,6 +844,10 @@ These fields have four other attributes and an additional method:
     ['Un', 'Deux']
     >>> ctrl.value
     ['1', '2']
+    >>> ctrl.displayValue = ['Quatre']
+    Traceback (most recent call last):
+    ...
+    ItemNotFoundError: Quatre
 
 - 'controls' gives you a list of the subcontrol objects in the control
   (subcontrols are discussed below).
@@ -1074,6 +1078,14 @@ Selection Control (Single-Valued)
     ['Third']
     >>> ctrl.value
     ['3']
+    >>> ctrl.displayValue = ['Quatre']
+    Traceback (most recent call last):
+    ...
+    ItemNotFoundError: Quatre
+    >>> ctrl.displayValue = ['Uno', 'Dos']
+    Traceback (most recent call last):
+    ...
+    ItemCountError: single selection list, must set sequence of length 0 or 1
 
 Selection Control (Multi-Valued)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1124,6 +1136,10 @@ Checkbox Control (Single-Valued; Unvalued)
     >>> browser.getControl(
     ...     name='single-disabled-unvalued-checkbox-value').disabled
     True
+    >>> ctrl.displayValue = ['Nonsense']
+    Traceback (most recent call last):
+    ...
+    ItemNotFoundError: Nonsense
 
 Checkbox Control (Single-Valued, Valued)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1166,6 +1182,10 @@ Checkbox Control (Single-Valued, Valued)
     False
     >>> ctrl.displayValue
     []
+    >>> ctrl.displayValue = ['Nonsense']
+    Traceback (most recent call last):
+    ...
+    ItemNotFoundError: Nonsense
 
   - Checkbox Control (Multi-Valued)
 
@@ -1209,6 +1229,10 @@ Checkbox Control (Single-Valued, Valued)
     >>> browser.getControl('Three').selected = False
     >>> ctrl.value
     []
+    >>> ctrl.displayValue = ['Four']
+    Traceback (most recent call last):
+    ...
+    ItemNotFoundError: Four
 
 Radio Control
 ~~~~~~~~~~~~~
@@ -1271,6 +1295,14 @@ This is just unit testing:
     ['1']
     >>> ctrl.displayValue
     ['Ein']
+    >>> ctrl.displayValue = ['Vier']
+    Traceback (most recent call last):
+    ...
+    ItemNotFoundError: Vier
+    >>> ctrl.displayValue = ['Ein', 'Zwei']
+    Traceback (most recent call last):
+    ...
+    ItemCountError: single selection list, must set sequence of length 0 or 1
 
 The radio control subcontrols were illustrated above.
 

--- a/src/zope/testbrowser/tests/test_browser.py
+++ b/src/zope/testbrowser/tests/test_browser.py
@@ -20,7 +20,11 @@ import io
 import doctest
 import unittest
 
-from zope.testbrowser.browser import Browser
+from zope.testbrowser.browser import (
+    Browser,
+    ItemCountError,
+    ItemNotFoundError,
+)
 import zope.testbrowser.tests.helper
 
 
@@ -130,6 +134,18 @@ class TestDisplayValue(unittest.TestCase):
         self.assertEqual(self.control.displayValue, ['Turn'])
         self.control.displayValue = []
         self.assertEqual(self.control.displayValue, [])
+
+    def test_displayValue_set_missing_value(self):
+        self.assertEqual(self.control.displayValue, ['Turn'])
+        self.assertRaises(
+            ItemNotFoundError, setattr, self.control, 'displayValue',
+            ['Missing'])
+
+    def test_displayValue_set_too_many_values(self):
+        self.assertEqual(self.control.displayValue, ['Turn'])
+        self.assertRaises(
+            ItemCountError, setattr, self.control, 'displayValue',
+            ['Turn', 'Alternative'])
 
 
 class TestMechRepr(unittest.TestCase):


### PR DESCRIPTION
Add error checking to the setters for `ListControl.displayValue` and
`CheckboxListControl.displayValue`: in line with the old
`mechanize`-based implementation, these will now raise
`ItemNotFoundError` if any of the given values are not found, or
`ItemCountError` on trying to set more than one value on a single-valued
control.

While this could technically be a backward-incompatibility in some
cases, non-matching elements of the requested value were previously
silently ignored, which seems overwhelmingly more likely to have
resulted in hidden bugs.

I considered adding similar checks to the corresponding `value` setters,
but as far as I can see `mechanize` didn't have such checks there, so
the compatibility bar for changes is higher.  Also, values are more
likely to be stable than labels, and are often shorter identifiers that
are somewhat less prone to typos.

Fixes #44.