### PR TITLE
Fix AttributeError 'mech_control'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ CHANGES
   control.  See `issue 44
   <https://github.com/zopefoundation/zope.testbrowser/issues/44>`_.
 
+- Fix AttributeError in `add_file` when trying to add to a control which is
+  not a file upload.
 
 5.5.0 (2019-11-11)
 ------------------

--- a/src/zope/testbrowser/browser.py
+++ b/src/zope/testbrowser/browser.py
@@ -721,7 +721,7 @@ class Control(SetattrErrorsMixin):
     def add_file(self, file, content_type, filename):
         if self.type != 'file':
             raise TypeError("Can't call add_file on %s controls"
-                            % self.mech_control.type)
+                            % self.type)
 
         if hasattr(file, 'read'):
             contents = file.read()


### PR DESCRIPTION
`mech_control` is no more. In the line above `self.type` is directly accessed.