### PR TITLE
Fix warning about legacy version specifiers in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'zope.interface',
         'zope.schema',
         'zope.cachedescriptors',
-        'pytz > dev',
+        'pytz',
         'WebTest >= 2.0.30',
         'BeautifulSoup4',
         'SoupSieve >= 1.9.0',


### PR DESCRIPTION
Warning on startup with recent setuptools:

```
pkg_resources/_vendor/packaging/specifiers.py:273: DeprecationWarning:
Creating a LegacyVersion has been deprecated and will be removed in the next major release
```

This reverts commit 89e919abd01f59d07e7ab7ab46f6a85abe1e032c from 2013 by @mgedmin with message:

    Make zope.testbrowser installable via pip

    Adds a workaround for the infamous pytz versioning scheme conflict with
    pip's new only-install-final-releases rule.

I guess that problem got fixed in more recent pip versions.