### PR TITLE
Fix PyPy3 tests in GHA.

### DIFF
--- a/src/zope/testbrowser/tests/helper.py
+++ b/src/zope/testbrowser/tests/helper.py
@@ -62,9 +62,10 @@ checker = zope.testing.renormalizing.RENormalizing([
     (re.compile(r'urllib.error.HTTPError'),
      'HTTPError'),
 
-
     # In py3 HTTPMessage class was moved and represented differently
     (re.compile(r'<http.client.HTTPMessage object'),
      '<httplib.HTTPMessage instance'),
-    # (re.compile(r''), ''),
+
+    # Ignore output returned by GHA for PyPy3
+    (re.compile('/etc/ssl/certs/ca-certificates.crt /etc/ssl/certs'), ''),
 ])


### PR DESCRIPTION
GHA decided to return unexpected texts, see https://github.com/zopefoundation/zope.testbrowser/actions/runs/6523930356/job/17715078554