### PR TITLE
Drop support for Python 3.7, add support for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,21 +17,23 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ["ubuntu", "ubuntu-20.04"]
+        - ["ubuntu", "ubuntu-latest"]
         - ["windows", "windows-latest"]
         config:
         # [Python version, tox env]
+        - ["3.9",   "release-check"]
         - ["3.9",   "lint"]
-        - ["3.7",   "py37"]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
         - ["3.11",  "py311"]
         - ["3.12",  "py312"]
-        - ["pypy-3.9", "pypy3"]
+        - ["3.13",  "py313"]
+        - ["pypy-3.10", "pypy3"]
         - ["3.9",   "docs"]
         - ["3.9",   "coverage"]
         exclude:
+          - { os: ["windows", "windows-latest"], config: ["3.9",   "release-check"] }
           - { os: ["windows", "windows-latest"], config: ["3.9",   "lint"] }
           - { os: ["windows", "windows-latest"], config: ["3.9",   "docs"] }
           - { os: ["windows", "windows-latest"], config: ["3.9",   "coverage"] }
@@ -40,13 +42,14 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.os[0] }}-${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.config[0] }}
+        allow-prereleases: true
     - name: Pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
@@ -58,7 +61,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox
     - name: Test
+      if: ${{ !startsWith(runner.os, 'Mac') }}
       run: tox -e ${{ matrix.config[1] }}
+    - name: Test (macOS)
+      if: ${{ startsWith(runner.os, 'Mac') }}
+      run: tox -e ${{ matrix.config[1] }}-universal2
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,12 +2,12 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "13b9049c"
+commit-id = "74cdfdf6"
 
 [python]
 with-windows = true
 with-pypy = true
-with-future-python = false
+with-future-python = true
 with-docs = true
 with-sphinx-doctests = true
 with-macos = false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@
 CHANGES
 =======
 
-6.1 (unreleased)
+7.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add support for Python 3.12 and 3.13 as of 3.13b1.
+
+- Drop support for Python 3.7.
 
 
 6.0 (2023-03-27)

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,12 @@
         :target: https://pypi.org/project/zope.testbrowser/
         :alt: Latest Version
 
+.. image:: https://img.shields.io/pypi/pyversions/zope.testbrowser.svg
+        :target: https://pypi.org/project/zope.testbrowser/
+        :alt: Supported Python versions
+
 .. image:: https://github.com/zopefoundation/zope.testbrowser/actions/workflows/tests.yml/badge.svg
         :target: https://github.com/zopefoundation/zope.testbrowser/actions/workflows/tests.yml
-
 
 .. image:: https://readthedocs.org/projects/zopetestbrowser/badge/?version=latest
         :target: http://zopetestbrowser.readthedocs.org/en/latest/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
-[bdist_wheel]
-universal = 0
 
 [flake8]
 doctests = 1

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,12 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Zope Public License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Testing',
@@ -58,7 +59,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     namespace_packages=['zope'],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
         'setuptools',
         'zope.interface',
@@ -69,6 +70,7 @@ setup(
         'BeautifulSoup4',
         'SoupSieve >= 1.9.0',
         'WSGIProxy2',
+        'legacy-cgi; python_version > "3.12"',  # WebOb uses the cgi module
     ],
     extras_require={
         'docs': [

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,12 @@ minversion = 3.18
 envlist =
     release-check
     lint
-    py37
     py38
     py39
     py310
     py311
     py312
+    py313
     pypy3
     docs
     coverage
@@ -19,7 +19,10 @@ envlist =
 usedevelop = true
 package = wheel
 wheel_build_env = .pkg
+pip_pre = py313: true
 deps =
+    setuptools < 69
+    Sphinx
 setenv =
     ZOPE_INTERFACE_STRICT_IRO=1
     py312: VIRTUALENV_PIP=23.1.2
@@ -40,9 +43,10 @@ deps =
     check-manifest
     check-python-versions >= 0.20.0
     wheel
+commands_pre =
 commands =
     check-manifest
-    check-python-versions
+    check-python-versions --only setup.py,tox.ini,.github/workflows/tests.yml
     python -m build --sdist --no-isolation
     twine check dist/*
 
@@ -79,12 +83,13 @@ allowlist_externals =
     mkdir
 deps =
     coverage
+    Sphinx
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
     coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
     coverage html --ignore-errors
-    coverage report --ignore-errors --show-missing --fail-under=70
+    coverage report --show-missing --fail-under=70
 
 [coverage:run]
 branch = True
@@ -92,6 +97,7 @@ source = zope.testbrowser
 
 [coverage:report]
 precision = 2
+ignore_errors = True
 exclude_lines =
     pragma: no cover
     pragma: nocover


### PR DESCRIPTION
Adding support for Python 3.13 comes at a "cost": I had to add a Python 3.13-only dependency on legacy-cgi, a port of the now-missing `cgi` module for use with Python 3.13, to the dependencies. The actual dependency on `cgi` is in `WebOb`, where the issue is known (https://github.com/Pylons/webob/issues/437) but no one seems to care and there hasn't been any release in several years. The dependency works around that issue.