### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 CHANGES
 =======
 
-7.1 (unreleased)
+8.0 (unreleased)
 ----------------
 
 - Drop support for Python 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ CHANGES
 8.0 (unreleased)
 ----------------
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 - Add preliminary support for Python 3.14.

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ tests_require = ['zope.testing', 'mock', 'zope.testrunner']
 
 setup(
     name='zope.testbrowser',
-    version='7.1.dev0',
+    version='8.0.dev0',
     url='https://github.com/zopefoundation/zope.testbrowser',
     license='ZPL-2.1',
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 ##############################################################################
 """Setup for zope.testbrowser package
 """
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -25,7 +24,7 @@ with open('CHANGES.rst') as f:
 
 long_description = (README + '\n\n' + CHANGES)
 
-tests_require = ['zope.testing', 'mock', 'zope.testrunner']
+tests_require = ['zope.testing', 'mock', 'zope.testrunner >= 6.4']
 
 setup(
     name='zope.testbrowser',
@@ -55,9 +54,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
     ],
     keywords='headless browser functional tests WSGI HTTP HTML form',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     python_requires='>=3.9',
     install_requires=[
         'setuptools',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
