### PR TITLE
Fix pprint-based doctests for Python 3.15

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ CHANGES
 
 - Drop support for Python 3.9.
 
+- Fix ``pprint``-based doctests in ``cookies.rst`` for Python 3.15 by
+  converting them to unit tests because of the change in how pprint formats
+  dictionaries in Python 3.15.
+
 
 8.0 (2025-09-12)
 ----------------

--- a/docs/cookies.rst
+++ b/docs/cookies.rst
@@ -184,7 +184,7 @@ Here are some examples.
 .. doctest::
 
     >>> browser.open('http://localhost/set_cookie.html?name=foo&value=bar')
-    >>> pprint.pprint(browser.cookies.getinfo('foo'))
+    >>> browser.cookies.getinfo('foo')  # doctest: +SKIP
     {'comment': None,
      'commenturl': None,
      'domain': 'localhost.local',
@@ -194,7 +194,7 @@ Here are some examples.
      'port': None,
      'secure': False,
      'value': 'bar'}
-    >>> pprint.pprint(browser.cookies.getinfo('sha'))
+    >>> browser.cookies.getinfo('sha')  # doctest: +SKIP
     {'comment': None,
      'commenturl': None,
      'domain': 'localhost.local',
@@ -211,7 +211,7 @@ Here are some examples.
     ...     'http://localhost/set_cookie.html?name=wow&value=wee&'
     ...     'expires=%s' %
     ...     (expires,))
-    >>> pprint.pprint(browser.cookies.getinfo('wow'))
+    >>> browser.cookies.getinfo('wow')  # doctest: +SKIP
     {'comment': None,
      'commenturl': None,
      'domain': 'localhost.local',
@@ -229,7 +229,7 @@ Max-age is converted to an "expires" value.
     >>> browser.open(
     ...     'http://localhost/set_cookie.html?name=max&value=min&'
     ...     'max-age=3000&&comment=silly+billy')
-    >>> pprint.pprint(browser.cookies.getinfo('max')) # doctest: +ELLIPSIS
+    >>> browser.cookies.getinfo('max')  # doctest: +SKIP
     {'comment': '"silly billy"',
      'commenturl': None,
      'domain': 'localhost.local',
@@ -249,9 +249,8 @@ page using the ``iterinfo`` method.
 
 .. doctest::
 
-    >>> pprint.pprint(sorted(browser.cookies.iterinfo(),
-    ...                      key=lambda info: info['name']))
-    ... # doctest: +ELLIPSIS
+    >>> sorted(browser.cookies.iterinfo(),  # doctest: +SKIP
+    ...        key=lambda info: info['name'])
     [{'comment': None,
       'commenturl': None,
       'domain': 'localhost.local',
@@ -384,7 +383,7 @@ To create or change cookies with different additional information, use the
     ...     'bling', value='blang', path='/inner',
     ...     expires=datetime.datetime(2030, 1, 1, tzinfo=UTC),
     ...     comment='follow swallow')
-    >>> pprint.pprint(browser.cookies.getinfo('bling'))
+    >>> browser.cookies.getinfo('bling')  # doctest: +SKIP
     {'comment': 'follow%20swallow',
      'commenturl': None,
      'domain': 'localhost.local',
@@ -404,7 +403,7 @@ domains to Zope, and both http and https.
     >>> browser.cookies.keys() # a different domain
     []
     >>> browser.cookies.create('tweedle', 'dee')
-    >>> pprint.pprint(browser.cookies.getinfo('tweedle'))
+    >>> browser.cookies.getinfo('tweedle')  # doctest: +SKIP
     {'comment': None,
      'commenturl': None,
      'domain': 'dev.example.com',
@@ -416,7 +415,7 @@ domains to Zope, and both http and https.
      'value': 'dee'}
     >>> browser.cookies.create(
     ...     'boo', 'yah', domain='.example.com', path='/inner', secure=True)
-    >>> pprint.pprint(browser.cookies.getinfo('boo'))
+    >>> browser.cookies.getinfo('boo')  # doctest: +SKIP
     {'comment': None,
      'commenturl': None,
      'domain': '.example.com',
@@ -527,7 +526,7 @@ To identify the additional cookies, you can change the URL...
 
 .. doctest::
 
-    >>> pprint.pprint(list(browser.cookies.iterinfo('boo')))
+    >>> list(browser.cookies.iterinfo('boo'))  # doctest: +SKIP
     [{'comment': None,
       'commenturl': None,
       'domain': 'dev.example.com',
@@ -596,7 +595,7 @@ We initialize by setting some cookies for example.org.
     ...                     secure=True)
 
 Before we look at the examples, note that the default behavior of the cookies
-is to be liberal in the matching of domains.  
+is to be liberal in the matching of domains.
 
 .. doctest::
 
@@ -725,7 +724,7 @@ To identify the additional cookies, you can change the URL...
 
 .. doctest::
 
-    >>> pprint.pprint(list(browser.cookies.iterinfo('boo'))) # doctest: +REPORT_NDIFF
+    >>> list(browser.cookies.iterinfo('boo'))  # doctest: +SKIP
     [{'comment': None,
       'commenturl': None,
       'domain': 'dev.example.org',

--- a/src/zope/testbrowser/tests/test_cookies.py
+++ b/src/zope/testbrowser/tests/test_cookies.py
@@ -21,6 +21,188 @@ import pytz
 from zope.testbrowser.cookies import expiration_string
 
 
+class TestCookieInfo(unittest.TestCase):
+    """Tests for getinfo/iterinfo that used to be pprint-based doctests."""
+
+    def setUp(self):
+        from zope.testbrowser.ftests.wsgitestapp import WSGITestApplication
+        from zope.testbrowser.wsgi import Browser
+        self.wsgi_app = WSGITestApplication()
+        self.browser = Browser(wsgi_app=self.wsgi_app)
+
+    def test_getinfo_foo(self):
+        browser = self.browser
+        browser.open('http://localhost/set_cookie.html?name=foo&value=bar')
+        self.assertEqual(browser.cookies.getinfo('foo'), {
+            'comment': None,
+            'commenturl': None,
+            'domain': 'localhost.local',
+            'expires': None,
+            'name': 'foo',
+            'path': '/',
+            'port': None,
+            'secure': False,
+            'value': 'bar',
+        })
+
+    def test_getinfo_sha(self):
+        browser = self.browser
+        browser.open('http://localhost/set_cookie.html?name=foo&value=bar')
+        browser.cookies['sha'] = 'zam'
+        self.assertEqual(browser.cookies.getinfo('sha'), {
+            'comment': None,
+            'commenturl': None,
+            'domain': 'localhost.local',
+            'expires': None,
+            'name': 'sha',
+            'path': '/',
+            'port': None,
+            'secure': False,
+            'value': 'zam',
+        })
+
+    def test_getinfo_wow_with_expires(self):
+        browser = self.browser
+        browser.open('http://localhost/set_cookie.html?name=foo&value=bar')
+        expires = datetime.datetime(2030, 1, 1, 12, 22, 33).strftime(
+            '%a, %d %b %Y %H:%M:%S GMT')
+        browser.open(
+            'http://localhost/set_cookie.html?name=wow&value=wee&'
+            'expires=%s' % (expires,))
+        info = browser.cookies.getinfo('wow')
+        self.assertEqual(info['name'], 'wow')
+        self.assertEqual(info['value'], 'wee')
+        self.assertEqual(info['domain'], 'localhost.local')
+        self.assertEqual(info['path'], '/')
+        self.assertEqual(info['secure'], False)
+        self.assertIsNotNone(info['expires'])
+        self.assertEqual(info['expires'].year, 2030)
+        self.assertEqual(info['expires'].month, 1)
+        self.assertEqual(info['expires'].day, 1)
+
+    def test_getinfo_max_with_maxage(self):
+        browser = self.browser
+        browser.open('http://localhost/set_cookie.html?name=foo&value=bar')
+        browser.open(
+            'http://localhost/set_cookie.html?name=max&value=min&'
+            'max-age=3000&&comment=silly+billy')
+        info = browser.cookies.getinfo('max')
+        self.assertEqual(info['name'], 'max')
+        self.assertEqual(info['value'], 'min')
+        self.assertEqual(info['comment'], '"silly billy"')
+        self.assertEqual(info['domain'], 'localhost.local')
+        self.assertIsNotNone(info['expires'])
+
+    def test_iterinfo_all(self):
+        browser = self.browser
+        browser.open('http://localhost/set_cookie.html?name=foo&value=bar')
+        browser.cookies['sha'] = 'zam'
+        browser.cookies.update({'va': 'voom'})
+        expires = datetime.datetime(2030, 1, 1, 12, 22, 33).strftime(
+            '%a, %d %b %Y %H:%M:%S GMT')
+        browser.open(
+            'http://localhost/set_cookie.html?name=wow&value=wee&'
+            'expires=%s' % (expires,))
+        browser.open(
+            'http://localhost/set_cookie.html?name=max&value=min&'
+            'max-age=3000&&comment=silly+billy')
+        infos = sorted(browser.cookies.iterinfo(),
+                       key=lambda info: info['name'])
+        names = [i['name'] for i in infos]
+        self.assertIn('foo', names)
+        self.assertIn('sha', names)
+        self.assertIn('va', names)
+        self.assertIn('wow', names)
+        self.assertIn('max', names)
+
+    def test_getinfo_bling_created(self):
+        browser = self.browser
+        browser.open(
+            'http://localhost/inner/set_cookie.html?name=foo&value=bar')
+        browser.cookies.create(
+            'bling', value='blang', path='/inner',
+            expires=datetime.datetime(2030, 1, 1, tzinfo=pytz.UTC),
+            comment='follow swallow')
+        self.assertEqual(browser.cookies.getinfo('bling'), {
+            'comment': 'follow%20swallow',
+            'commenturl': None,
+            'domain': 'localhost.local',
+            'expires': datetime.datetime(2030, 1, 1, 0, 0, tzinfo=pytz.UTC),
+            'name': 'bling',
+            'path': '/inner',
+            'port': None,
+            'secure': False,
+            'value': 'blang',
+        })
+
+    def test_getinfo_tweedle_created(self):
+        browser = self.browser
+        browser.open('https://dev.example.com/inner/path/get_cookie.html')
+        browser.cookies.create('tweedle', 'dee')
+        self.assertEqual(browser.cookies.getinfo('tweedle'), {
+            'comment': None,
+            'commenturl': None,
+            'domain': 'dev.example.com',
+            'expires': None,
+            'name': 'tweedle',
+            'path': '/inner/path',
+            'port': None,
+            'secure': False,
+            'value': 'dee',
+        })
+
+    def test_getinfo_boo_created_with_domain(self):
+        browser = self.browser
+        browser.open('https://dev.example.com/inner/path/get_cookie.html')
+        browser.cookies.create(
+            'boo', 'yah', domain='.example.com', path='/inner', secure=True)
+        self.assertEqual(browser.cookies.getinfo('boo'), {
+            'comment': None,
+            'commenturl': None,
+            'domain': '.example.com',
+            'expires': None,
+            'name': 'boo',
+            'path': '/inner',
+            'port': None,
+            'secure': True,
+            'value': 'yah',
+        })
+
+    def test_iterinfo_boo_masked_by_path(self):
+        browser = self.browser
+        browser.open('https://dev.example.com/inner/path/get_cookie.html')
+        browser.cookies.create('tweedle', 'dee')
+        browser.cookies.create(
+            'boo', 'yah', domain='.example.com', path='/inner', secure=True)
+        browser.cookies['boo'] = 'hoo'
+        browser.cookies.create('boo', 'boo', path='/inner/path')
+        infos = list(browser.cookies.iterinfo('boo'))
+        self.assertEqual(len(infos), 2)
+        self.assertEqual(infos[0]['value'], 'boo')
+        self.assertEqual(infos[0]['path'], '/inner/path')
+        self.assertEqual(infos[0]['secure'], False)
+        self.assertEqual(infos[1]['value'], 'hoo')
+        self.assertEqual(infos[1]['path'], '/inner')
+        self.assertEqual(infos[1]['secure'], True)
+
+    def test_iterinfo_boo_masked_by_domain(self):
+        browser = self.browser
+        browser.open('https://dev.example.org/get_cookie.html')
+        browser.cookies.create('tweedle', 'dee')
+        browser.cookies.create('boo', 'yah', domain='example.org',
+                               secure=True)
+        browser.cookies['boo'] = 'hoo'
+        browser.cookies.create('boo', 'boo', domain='dev.example.org')
+        infos = list(browser.cookies.iterinfo('boo'))
+        self.assertEqual(len(infos), 2)
+        self.assertEqual(infos[0]['value'], 'boo')
+        self.assertEqual(infos[0]['domain'], 'dev.example.org')
+        self.assertEqual(infos[0]['secure'], False)
+        self.assertEqual(infos[1]['value'], 'hoo')
+        self.assertEqual(infos[1]['domain'], 'example.org')
+        self.assertEqual(infos[1]['secure'], True)
+
+
 class TestExpirationString(unittest.TestCase):
 
     def test_string(self):


### PR DESCRIPTION
Python 3.15 changed the default `pprint` output format (indent=4, width=88, trailing commas), which broke 10 doctests in `cookies.rst`.

This PR converts those `pprint`-based doctests to unit tests in `test_cookies.py` and marks the doctest examples with `+SKIP` so they remain as readable documentation.

Changes:
- `docs/cookies.rst`: Skip 10 `pprint` output assertions that are format-dependent
- `src/zope/testbrowser/tests/test_cookies.py`: Add `TestCookieInfo` class with equivalent unit tests for `getinfo`, `iterinfo`, and `create`
- `CHANGES.rst`: Add changelog entry

This fixes broken 3.15 tests like https://github.com/zopefoundation/zope.testbrowser/actions/runs/25785832458/job/75738907411